### PR TITLE
remove some non-ls stuff

### DIFF
--- a/pages/common/ls.md
+++ b/pages/common/ls.md
@@ -18,12 +18,6 @@
 
 `ls -lh`
 
-- List all files with a prefix/suffix
-
-`ls {{prefix}}*`
-
-`ls *{{suffix}}`
-
 - Sort the results by size, last modified date, or creation date
 
 `ls -S`


### PR DESCRIPTION
The globbing ({prefix}* or *{suffix} or what*ever) is provided by the shell and not by `ls`.